### PR TITLE
feat(sarif-to-comment): add an option to fail on specific severity

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: 'SARIF file is in OWASP Dependency Check dialect.'
     default: 'false'
     required: false
+  failon:
+    description: 'Throw an exit error code 1 if an issue with that level was detected, warning, error, note, none, or all. List must be comma separated.'
+    default: ''
+    required: false
 outputs:
   output:
     description: 'The output of the docker run.'
@@ -50,6 +54,7 @@ runs:
     - ${{ inputs.show-rule-details }}
     - ${{ inputs.dry-run }}
     - ${{ inputs.odc-sarif }}
+    - ${{ inputs.failon }}
 branding:
   icon: 'git-pull-request'
   color: 'green'

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
     default: 'false'
     required: false
   failon:
-    description: 'Throw an exit error code 1 if an issue with that level was detected, warning, error, note, none, or all. List must be comma separated.'
+    description: 'Comma-separated list of levels (warning, error, note, none, all) that will cause the action to exit with error code 1 if detected.'
     default: ''
     required: false
 outputs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,7 @@
 # $7 - show-rule-details
 # $8 - dry-run
 # $9 - odc-sarif
+# $10 - failon
 
 set -o pipefail
 set -eu
@@ -30,6 +31,7 @@ TITLE=$6
 SHOW_RULE_DETAILS=$7
 DRY_RUN=$8
 ODC_SARIF=$9
+FAILON=$([  -z "${10}" ] && echo "" || echo $(jq 'split(",")' -Rc <(echo "${10}") | jq -cr 'map(. |= "--failon \(.)") | join(" ")'))
 
 OWNER=$(echo "$REPOSITORY" | awk -F[/] '{print $1}')
 REPO=$(echo "$REPOSITORY" | awk -F[/] '{print $2}')
@@ -76,7 +78,7 @@ echo "Convert SARIF file $1"
 # --dryRun
 # --ruleDetails
 # sarif-file-path
-npx @security-alert/sarif-to-comment --dryRun "$DRY_RUN" --token "$TOKEN" --commentUrl "$URL" --sarifContentOwner "$OWNER" --sarifContentRepo "$REPO" --sarifContentBranch "$BRANCH" --title "$TITLE" --ruleDetails "$SHOW_RULE_DETAILS" "$SARIF_FILE"
+npx @security-alert/sarif-to-comment --dryRun "$DRY_RUN" --token "$TOKEN" --commentUrl "$URL" --sarifContentOwner "$OWNER" --sarifContentRepo "$REPO" --sarifContentBranch "$BRANCH" --title "$TITLE" --ruleDetails "$SHOW_RULE_DETAILS" $FAILON "$SARIF_FILE"
 RC=$?
 #echo "output={$RC}" >>"$GITHUB_OUTPUT"
 echo "RC = $RC"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,16 @@ TITLE=$6
 SHOW_RULE_DETAILS=$7
 DRY_RUN=$8
 ODC_SARIF=$9
-FAILON=$([  -z "${10}" ] && echo "" || echo $(jq 'split(",")' -Rc <(echo "${10}") | jq -cr 'map(. |= "--failon \(.)") | join(" ")'))
+
+transform_failon() {
+  local input="$1"
+  if [ -z "$input" ]; then
+    echo ""
+  else
+    jq 'split(",")' -Rc <(echo "$input") | jq -cr 'map(. |= "--failon \(.)") | join(" ")'
+  fi
+}
+FAILON=$(transform_failon "${10}")
 
 OWNER=$(echo "$REPOSITORY" | awk -F[/] '{print $1}')
 REPO=$(echo "$REPOSITORY" | awk -F[/] '{print $2}')


### PR DESCRIPTION
# Pull Request

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] pre-commit was run locally and any changes were pushed
- [x] test/test.sh has passed locally and any fixes were made for failures

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The action currently does not support `--failon` flag.

Issue URL: #174 

## What is the new behavior?

A `failon` input parameter has been added as a comma separated list of levels.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

N/A

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduced a new `failon` input parameter to allow the action to fail based on specified severity levels. Updated documentation and added tests to support this new feature.

* **New Features**:
    - Added a `failon` input parameter to specify severity levels that should trigger a failure.
* **Documentation**:
    - Updated documentation to include the new `failon` input parameter.
* **Tests**:
    - Added tests to verify the functionality of the new `failon` input parameter.

<!-- Generated by sourcery-ai[bot]: end summary -->