### PR TITLE
fix docker jq package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN npm install --ignore-scripts  --global npm@11.1.0 && \
 RUN rm -rf /root/.npm /root/.cache
 
 # Install jq and dependency security patches
-RUN apt-get update && apt-get install --no-install-recommends -y jq=1.6-2.1 \
+RUN apt-get update && apt-get install --no-install-recommends -y jq=1.6-2.1+deb11u1 \
         e2fsprogs=1.46.2-2+deb11u1 \
         libsystemd0=247.3-7+deb11u6 \
         logsave=1.46.2-2+deb11u1 \


### PR DESCRIPTION
This is a fix for Dockerfile to install the proper `jq` version.