### PR TITLE
Fix Docker image build in CI test

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -32,7 +32,7 @@ jobs:
             production.cloudflare.docker.com:443
             registry-1.docker.io:443
             registry.npmjs.org:443
-            pipelinesghubeus6.actions.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
 
       - name: "Checkout code"
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1


### PR DESCRIPTION
# Pull Request

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] pre-commit was run locally and any changes were pushed
- [x] test/test.sh has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are expected for both bug fixes and features. -->

CI tests are failing to build docker image

Issue URL: #482 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
Add missing egress

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Summary by Sourcery

CI:
- Adjust CI network egress allowlist to use release-assets.githubusercontent.com instead of the previous GitHub hostname for outbound access during tests.